### PR TITLE
Update node.extend version to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
   },
   "homepage": "https://github.com/floatdrop/configs-overload",
   "devDependencies": {
-    "mocha": "~1.17.0",
-    "mocha-lcov-reporter": "~0.0.1",
+    "chai": "~1.9.0",
     "coveralls": "~2.8.0",
     "istanbul": "~0.2.3",
-    "jshint": "~2.4.4",
     "jscs": "~1.3.0",
-    "chai": "~1.9.0"
+    "jshint": "~2.4.4",
+    "mocha": "~1.17.0",
+    "mocha-lcov-reporter": "~0.0.1"
   },
   "dependencies": {
-    "node.extend": "~1.0.9"
+    "node.extend": "~1.1.7"
   }
 }


### PR DESCRIPTION
Previous node.extend versions had critical vulnerability